### PR TITLE
Include an error code for each response

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -109,6 +109,7 @@ impl OutputFormat {
                         "answers": json_answers(response.answers),
                         "authorities": json_answers(response.authorities),
                         "additionals": json_answers(response.additionals),
+                        "error": json_error_code(response.flags.error_code)
                     };
 
                     rs.push(json);
@@ -600,6 +601,23 @@ fn json_record_data(record: Record) -> JsonValue {
     }
 }
 
+fn json_error_code(error: Option<ErrorCode>) -> JsonValue {
+    match error {
+        None => JsonValue::Null,
+        Some(err) => 
+            match err {
+                ErrorCode::FormatError    => "FormErr".into(),
+                ErrorCode::ServerFailure  => "ServFail".into(),
+                ErrorCode::NXDomain       => "NXDomain".into(),
+                ErrorCode::NotImplemented => "NotImp".into(),
+                ErrorCode::QueryRefused   => "Refused".into(),
+                ErrorCode::BadVersion     => "BADVERS".into(), // BADVERS & BADSIG have the same enum value
+                
+                ErrorCode::Other(u16)   => (format!("OTHER_{}",   u16)).into(),
+                ErrorCode::Private(u16) => (format!("PRIVATE_{}", u16)).into(),
+            }
+    }
+}
 
 /// A wrapper around displaying characters that escapes quotes and
 /// backslashes, and writes control and upper-bit bytes as their number rather


### PR DESCRIPTION
This PR updates the output to include a new `error` field for each item in `responses[]`.
The field will be `null` if no error exists for that response.

Closes #28 

Formatted response when querying an existing domain with `cargo run -- --json dns.lookup.dog`:
```json
{
   "responses":[
      {
         "queries":[
            {
               "name":"dns.lookup.dog.",
               "class":"IN",
               "type":"A"
            }
         ],
         "answers":[
            {
               "name":"dns.lookup.dog.",
               "class":"IN",
               "ttl":0,
               "type":"A",
               "data":{
                  "address":"51.159.146.31"
               }
            },
            {
               "name":"dns.lookup.dog.",
               "class":"IN",
               "ttl":0,
               "type":"A",
               "data":{
                  "address":"51.159.149.163"
               }
            }
         ],
         "authorities":[],
         "additionals":[],
         "error":null
      }
   ]
}
```

Formatted response when querying a non-existent domain with `cargo run -- --json dns.lookup123.dog`:
```json
{
   "responses":[
      {
         "queries":[
            {
               "name":"dns.lookup123.dog.",
               "class":"IN",
               "type":"A"
            }
         ],
         "answers":[],
         "authorities":[
            {
               "name":"dog.",
               "class":"IN",
               "ttl":1800,
               "type":"SOA",
               "data":{
                  "mname":"v0n0.nic.dog.",
                  "rname":"hostmaster.donuts.email.",
                  "serial":1714974458,
                  "refresh_interval":7200,
                  "retry_interval":900,
                  "expire_limit":1209600,
                  "minimum_ttl":3600
               }
            }
         ],
         "additionals":[],
         "error":"NXDomain"
      }
   ]
}
```

