### PR TITLE
updating doge transport dependency for ipv6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "doge_transport"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d86321702916d28a95a1137291e5f7de57e496d94d7f53b306469d802b62c66"
+checksum = "fa9645f94826864bb8a0bb78291dee9b6f01ed7ad011123539b3fe203471424d"
 dependencies = [
  "cfg-if",
  "doge_dns",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ panic = "abort"
 
 # dns stuff
 doge_dns = "1.0.2"
-doge_transport = "0.2.5"
+doge_transport = "0.2.6"
 
 # command-line
 ansi_term = "0.12"


### PR DESCRIPTION
Adding v0.2.6 for doge_transport with ipv6 support