### PR TITLE
updating doge transport dependency for ipv6 (#48) (#49)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "doge_transport"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d86321702916d28a95a1137291e5f7de57e496d94d7f53b306469d802b62c66"
+checksum = "fa9645f94826864bb8a0bb78291dee9b6f01ed7ad011123539b3fe203471424d"
 dependencies = [
  "cfg-if",
  "doge_dns",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ panic = "abort"
 
 # dns stuff
 doge_dns = "1.0.2"
-doge_transport = "0.2.5"
+doge_transport = "0.2.6"
 
 # command-line
 ansi_term = "0.12"

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -89,6 +89,7 @@ impl Resolver {
 fn system_nameservers() -> Result<Resolver, ResolverLookupError> {
     use std::fs::File;
     use std::io::{BufRead, BufReader};
+    use std::net::IpAddr;
 
     if cfg!(test) {
         panic!("system_nameservers() called from test code");
@@ -103,7 +104,7 @@ fn system_nameservers() -> Result<Resolver, ResolverLookupError> {
         let line = line?;
 
         if let Some(nameserver_str) = line.strip_prefix("nameserver ") {
-            let ip: Result<std::net::Ipv4Addr, _> = nameserver_str.parse();
+            let ip: Result<IpAddr, _> = nameserver_str.parse();
             // TODO: This will need to be changed for IPv6 support.
 
             match ip {


### PR DESCRIPTION
Adding Ipv6 parsing for `/etc/resolv.conf` and cli parsing