### PR TITLE
build: added more options to optimize release binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ debug = true
 lto = true
 overflow-checks = true
 panic = "abort"
+strip = true
+opt-level = "z"
 
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
     <code>doge example.net MX</code>                       ...looking up MX records instead
     <code>doge example.net MX @1.1.1.1</code>              ...using a specific nameserver instead
     <code>doge example.net MX @1.1.1.1 -T</code>           ...using TCP rather than UDP
-    <code>doge exapple.net MX @1.1.1.1 -p 69</code>        ...using a nonstandard port
+    <code>doge example.net MX @1.1.1.1 -p 69</code>        ...using a nonstandard port
     <code>doge -q example.net -t MX -n 1.1.1.1 -T</code>   As above, but using explicit arguments
   </pre>
 
@@ -90,7 +90,7 @@
     <pre>
         <code>Homebrew: brew install doge
         Cargo: cargo install dns-doge
-        ArchLinux: yay -S dns_doge
+        ArchLinux: yay -S dns-doge
         Ubuntu/Debian: Comming Soon
         RHEL/Fedora/Cenos: Publishing rpm</code>
     </pre>

--- a/makefile
+++ b/makefile
@@ -12,14 +12,13 @@ build:
 
 build-release:
 	@cargo build --release --verbose
-	# @strip "${CARGO_TARGET_DIR:-target}/release/doge"
 
 build-time:
 	@cargo +nightly clean
 	@cargo +nightly build -Z timings
 
 build-quick:
-	@cargo build --no-default-features	
+	@cargo build --no-default-features
 
 # Check the compilation
 check:


### PR DESCRIPTION
I am still a bit of a newb to Rust myself so I am not fully confident in the best [opt-level](https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level) to use, or to leave it as default (`0`). For doge, I'd be tempted to desire smaller binaries at the cost of performance; I'm not sure that its use case is one where you're going to see a noticeable change anyway...I tried to do some benchmarks with hyperfine and every command I ran (even with the opt-level "z" binary) ran in under 2.5ms.

Meanwhile, the reduction in binary in size, depending on the target, can be pretty significant.

Here are the numbers based on [the v0.2.9 release](https://github.com/Dj-Codeman/dog_community/releases/tag/v0.2.9) and [this run on my fork](https://github.com/goto-dev-null/dog_community/actions/runs/22813595302):

| Target         | Before | After | Reduction |
|----------------|--------|-------|-----------|
| linux-x86_64   | 6.8M   | 6.6M  | 3%        |
| linux-i686     | 5.1M   | 4.9M  | 4%        |
| linux-aarch64  | 6.0M   | 5.2M  | 13%       |
| linux-armv7    | 3.9M   | 3.1M  | 21%       |
| apple          | 2.4M   | 1.9M  | 21%       |
| windows-x86_64 | 1017K  | 864K  | 15%       |
| windows-i686   | 779K   | 640K  | 18%       |

## opt-level 3

Out of my own curiosity, I wanted to see the difference between `opt-level = "z"` and `opt-level = 3`. Here's the comparison for [this run on my fork](https://github.com/goto-dev-null/dog_community/actions/runs/22814256572):

| Target         | Before | After | Reduction |
|----------------|--------|-------|-----------|
| linux-x86_64   | 6.8M   | 6.7M  | 1%        |
| linux-i686     | 5.1M   | 5.0   | 2%        |
| linux-aarch64  | 6.0M   | 5.3M  | 12%       |
| linux-armv7    | 3.9M   | 3.2M  | 18%       |
| apple          | 2.4M   | 2.2M  | 8%        |
| windows-x86_64 | 1017K  | 978K  | 4%        |
| windows-i686   | 779K   | 752K  | 3%        |

So `opt-level = "z"` seems to be have way more of an affect on apple and windows and less on linux, which I find fascinating.