### PR TITLE
chore: repository added to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ exclude = [
     "/dog-screenshot.png", "/Justfile", "/README.md", "/.rustfmt.toml", "/.travis.yml", "/makefile",
 ]
 homepage = "https://dog.ramfield.net/"
+repository = "https://github.com/Dj-Codeman/dog_community"
 license = "MIT"
 
 version = "0.2.9"


### PR DESCRIPTION
I just kinda arbitrarily chose where in the file to put it.

The impetus of this is to address the warnings about a missing repo when using cargo-binstall, as discussed in https://github.com/Dj-Codeman/dog_community/issues/62

I have not published to crates.io so I have no idea if there's anything that needs to be get to be updated there, or if it is automatic :\